### PR TITLE
Fix errors with multiple servers

### DIFF
--- a/Guild.py
+++ b/Guild.py
@@ -3,11 +3,11 @@ from Scoreboard import Scoreboard
 
 class Guild:
 
-    def __init__(self, guild_name, guild_id, scoreboard_shortest = Scoreboard(use_type=False), scoreboard_longest = Scoreboard(use_type=True)):
+    def __init__(self, guild_name, guild_id, scoreboard_shortest=None, scoreboard_longest=None):
         self.g_name = guild_name
         self.g_id = guild_id
-        self.shortest = scoreboard_shortest
-        self.longest = scoreboard_longest
+        self.shortest = Scoreboard(use_type=False) if scoreboard_shortest is None else scoreboard_shortest
+        self.longest = Scoreboard(use_type=True) if scoreboard_longest is None else scoreboard_longest
 
     def check_shortest(self, time):
         return self.shortest.check(time)


### PR DESCRIPTION
This PR fixes problems with multiple servers.
1. The Update Message was send to all severs due to iterating over all the guilds from the client instance
 
2. The Leaderboard was shared due to default parameters only beeing evaluated once and acting like a static afterwards


Added channel creation if the "voice-speedrun" channel does not exist